### PR TITLE
Update build and run for national-parks

### DIFF
--- a/hooks/init
+++ b/hooks/init
@@ -1,10 +1,9 @@
 #!/bin/bash
-
 exec 2>&1
 
 echo "Seeding Mongo Collection"
 
-MONGODB_HOME=$(hab pkg path core/mongo-tools)
+MONGODB_HOME="{{pkgPathFor "core/mongo-tools"}}"
 
 source {{pkg.svc_config_path}}/mongoimport-opts.conf
 echo "\$MONGOIMPORT_OPTS=$MONGOIMPORT_OPTS"
@@ -25,5 +24,15 @@ echo "pkg.svc_files_path    = {{pkg.svc_files_path}}"
 echo "pkg.svc_static_path   = {{pkg.svc_static_path}}"
 echo "pkg.svc_var_path      = {{pkg.svc_var_path}}"
 
-echo ${MONGODB_HOME}/bin/mongoimport --drop -d demo -c nationalparks --type json --jsonArray --file $(hab pkg path {{pkg.origin}}/national-parks)/national-parks.json ${MONGOIMPORT_OPTS}
-${MONGODB_HOME}/bin/mongoimport --drop -d demo -c nationalparks --type json --jsonArray --file $(hab pkg path {{pkg.origin}}/national-parks)/national-parks.json ${MONGOIMPORT_OPTS}
+echo ${MONGODB_HOME}/bin/mongoimport --drop -d demo -c nationalparks --type json --jsonArray --file {{pkg.path}}/national-parks.json ${MONGOIMPORT_OPTS}
+${MONGODB_HOME}/bin/mongoimport --drop -d demo -c nationalparks --type json --jsonArray --file {{pkg.path}}/national-parks.json ${MONGOIMPORT_OPTS}
+
+# Copy tomcat into the service var path
+if [[ ! -d {{pkg.svc_var_path}}/tc ]]; then
+	cp -a {{pkgPathFor "core/tomcat8"}}/tc {{pkg.svc_var_path}}/
+fi
+
+# Install the app
+if [[ ! -d {{pkg.svc_var_path}}/tc/webapps/national-parks ]]; then
+	cp -a {{pkg.path}}/national-parks.war {{pkg.svc_var_path}}/tc/webapps/
+fi

--- a/hooks/run
+++ b/hooks/run
@@ -1,13 +1,15 @@
 #!/bin/bash
-
 exec 2>&1
 
 echo "Starting Apache Tomcat"
 
-export JAVA_HOME=$(hab pkg path core/jdk8)
-export TOMCAT_HOME="$(hab pkg path core/tomcat8)/tc"
+export JAVA_HOME="{{pkgPathFor "core/jdk8"}}"
+export TOMCAT_HOME="{{pkg.svc_var_path}}/tc"
+export CATALINA_BASE="{{pkg.svc_var_path}}/tc"
+export CATALINA_HOME="{{pkg.svc_var_path}}/tc"
 
 source {{pkg.svc_config_path}}/catalina-opts.conf
 echo "\$CATALINA_OPTS=$CATALINA_OPTS"
 
 exec ${TOMCAT_HOME}/bin/catalina.sh run
+

--- a/plan.sh
+++ b/plan.sh
@@ -5,7 +5,7 @@ pkg_version=0.1.5
 pkg_maintainer="Bill Meyer <bill@chef.io>"
 pkg_license=('Apache-2.0')
 pkg_source=https://github.com/billmeyer/national-parks
-pkg_deps=(core/tomcat8 core/jdk8 core/mongo-tools)
+pkg_deps=(core/tomcat8 core/jre8 core/mongo-tools)
 pkg_build_deps=(core/git core/maven)
 pkg_expose=(8080)
 pkg_svc_user="root"
@@ -64,11 +64,11 @@ do_install()
     # in the package.
 
     local source_dir="${HAB_CACHE_SRC_PATH}/${pkg_dirname}/${pkg_filename}"
-    local webapps_dir="$(hab pkg path core/tomcat8)/tc/webapps"
-    cp ${source_dir}/target/${pkg_filename}.war ${webapps_dir}/
+
+    cp -a "${source_dir}/target/${pkg_filename}.war" "${pkg_prefix}/national-parks.war"
 
     # Copy our seed data so that it can be loaded into Mongo using our init hook
-    cp -v ${source_dir}/national-parks.json ${PREFIX}/
+    cp -v "${source_dir}/national-parks.json" "${pkg_prefix}/"
 }
 
 # We verify our own source code because we cloned from GitHub instead of


### PR DESCRIPTION
This PR address a bug in the do_install method in plan.sh that copies the resulting artifact into the tomcat package, rather than the national-parks artifact.  This results in an "empty" package when uploaded to the depot.

* Update do_install to install package into the national-parks artifact path
* Update init/run to use newly available template helpers
* Update init/run to run the application from pkg.svc_var_path